### PR TITLE
NIST FIPS pq algorithm support

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,7 +160,7 @@ kafkacrypto has been extensively tested with kafka-python. It will use confluent
 
 ### Prerequisites
 
-Use requires installing [liboqs-python](https://github.com/open-quantum-safe/liboqs-python) with the sntrup761 algorithm enabled (the default).
+Use requires installing [liboqs-python](https://github.com/open-quantum-safe/liboqs-python) with the sntrup761, ML-KEM-1024, and SPINCS+-SHAKE-128f-simple algorithms enabled (the default).
 
 For raspberry pis and other devices not officially supported by liqoqs, the following may help:
 ```
@@ -191,13 +191,13 @@ Starting with version v0.9.10.0, kafkacrypto supports key exchange using Curve25
 
 Starting with version v0.9.11.0, kafkacrypto supports key exchange using Curve25519+ML-KEM-1024, a hybrid classical-pq key exchange algorithm, including the FIPS-standardized ML-KEM.
 
-The script `enable-pq-exchange.py` assists in enabing pq key exchange (see code documentation). It must be enabled on both consumers and producers.
+The script `enable-pq-exchange.py` assists in enabing pq key exchange. It must be enabled on both consumers and producers. Optionally, it can be used to select only a pq hybrid algorithm (see code documentation).
 
 ### Signing Keys
 
 Starting with version v0.9.11.0, kafkacrypto supports key signing using Ed25519+SLH-DSA-SHAKE-128f, a hybrid classical-pq signing algorithm, including the FIPS-standardized SLH-DSA.
 
-To enable pq signing, simply select a PQ signing key when provisioning. Note that provisioning can be run multiple times for a single node to create keys of multiple types.
+To enable pq signing, simply select a pq signing key when provisioning. Note that provisioning can be run multiple times for a single node to create keys of multiple types. Adding the line `keytypes : 4` just under the cryptokey line in `my-node-ID.config` can be used to enable only hybrid pq signing.
 
 Note that to use password-based deterministic key provisioners, you also need to install [pyspx-slhdsa](https://github.com/tmcqueen-materials/pyspx-slhdsa). We hope to remove this dependency once liboqs-python exposes seed-based key generation.
 

--- a/kafkacrypto/base.py
+++ b/kafkacrypto/base.py
@@ -98,8 +98,19 @@ class KafkaCryptoBase(object):
       if (cryptokey is None):
         cryptokey = nodeID + '.crypto'
         self._cryptostore.store_value('cryptokey', 'file#' + cryptokey)
-    if (isinstance(cryptokey,(str))):
-      cryptokey = CryptoKey(file=cryptokey)
+    if (isinstance(cryptokey,(str,))):
+      keytypes = self._cryptostore.load_value('keytypes')
+      if isinstance(keytypes,(int,)):
+        force_keytypes = True
+        keytypes = [keytypes]
+      elif not (keytypes is None):
+        force_keytypes = True
+        keytypes = [int(kt.strip()) for kt in keytypes.split(',')]
+      else:
+        force_keytypes = False
+      if not (keytypes is None):
+        self._logger.info("Using keytypes=%s", str(keytypes))
+      cryptokey = CryptoKey(file=cryptokey,keytypes=keytypes,force_keytypes=force_keytypes)
     if (not hasattr(cryptokey, 'get_id_spk') or not inspect.isroutine(cryptokey.get_id_spk) or not hasattr(cryptokey, 'get_num_spk') or not inspect.isroutine(cryptokey.get_num_spk) or
         not hasattr(cryptokey, 'get_spk') or not inspect.isroutine(cryptokey.get_spk) or not hasattr(cryptokey, 'sign_spk') or not inspect.isroutine(cryptokey.sign_spk) or
         not hasattr(cryptokey, 'get_epks') or not inspect.isroutine(cryptokey.get_epks) or not hasattr(cryptokey, 'use_epks') or not inspect.isroutine(cryptokey.use_epks) or

--- a/kafkacrypto/keys.py
+++ b/kafkacrypto/keys.py
@@ -232,6 +232,8 @@ class SignSecretKey(object):
       return "(Ed25519-SLH-DSA-SHAKE-128f-Secret, [" + self.keys[0].hex() + "," + self.keys[1].hex() + "])"
     else:
       return "(Unparsable)"
+  def get_type(self):
+    return self.version
   def __eq__(self, pk2):
     if isinstance(pk2, (SignSecretKey,)) and self.version == pk2.version:
       if self.version == 1 and self.keys == pk2.keys:
@@ -339,6 +341,8 @@ class KEMPublicKey(object):
       return "(Curve25519-ML-KEM-1024-ct, [" + self.keys[0].hex() + "," + self.keys[1].hex() + "])"
     else:
       return "(Unparsable)"
+  def get_type(self):
+    return self.version
   def __eq__(self, pk2):
     if isinstance(pk2, (KEMPublicKey,)) and self.version == pk2.version:
       if self.version == 1 and self.keys == pk2.keys:
@@ -451,6 +455,8 @@ class KEMSecretKey(object):
       return "(Curve25519-ML-KEM-1024-Secret-ct, [" + self.keys[0].hex() + ",[" + self.keys[1][0].hex() + "," + self.keys[1][1].hex() + "," + self.keys[1][2].hex() + "]])"
     else:
       return "(Unparsable)"
+  def get_type(self):
+    return self.version
   def __eq__(self, pk2):
     if isinstance(pk2, (KEMSecretKey,)) and self.version == pk2.version:
       if self.version == 1 and self.keys == pk2.keys:


### PR DESCRIPTION
This PR completes initial support of pq crypto for both exchange and signing, using ML-KEM-1024 and SLH-DSA-SHAKE-128f (key exchange and signature pq algorithms recently standardized by NIST).

As this currently relies on [liboqs](https://github.com/open-quantum-safe/liboqs), the pq support should be considered experimental. Closes #2 .